### PR TITLE
fix paper-material size

### DIFF
--- a/paper-card.html
+++ b/paper-card.html
@@ -58,11 +58,14 @@ Custom property | Description | Default
         box-sizing: border-box;
 
         background: #fff;
+        border-radius: 2px;
         @apply(--paper-card);
       }
 
-      #shadow {
-        border-radius: 2px;
+      paper-material {
+        border-radius: inherit;
+        width: 100%;
+        height: 100%;
       }
 
       /* IE 10 support for HTML5 hidden attr */
@@ -109,7 +112,7 @@ Custom property | Description | Default
       }
     </style>
 
-    <paper-material id="shadow" animated$="[[animatedShadow]]" elevation=[[elevation]]>
+    <paper-material animated$="[[animatedShadow]]" elevation="[[elevation]]">
       <div class="header">
         <img hidden$="[[!image]]" src="[[image]]">
         <div hidden$="[[!heading]]" class$="[[_computeHeadingClass(image)]]">[[heading]]</div>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-card/issues/18 (otherwise, resizing the card leaves the `paper-material` behind)

I also "fixed" the fix in https://github.com/PolymerElements/paper-card/pull/15 (I noticed that `paper-button` has the `paper-material` inherit the border, which i think is better than just moving the border to the material itself)