### PR TITLE
fix material size again

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
-    "paper-material": "PolymerElements/paper-material#^1.0.0"
+    "paper-material": "PolymerElements/paper-material#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/paper-card.html
+++ b/paper-card.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-material/paper-material.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <!--
 Material Design: <a href="http://www.google.com/design/spec/components/cards.html">Cards</a>
@@ -64,8 +65,7 @@ Custom property | Description | Default
 
       paper-material {
         border-radius: inherit;
-        width: 100%;
-        height: 100%;
+        @apply(--layout-fit);
       }
 
       /* IE 10 support for HTML5 hidden attr */
@@ -112,16 +112,14 @@ Custom property | Description | Default
       }
     </style>
 
-    <paper-material animated$="[[animatedShadow]]" elevation="[[elevation]]">
-      <div class="header">
-        <img hidden$="[[!image]]" src="[[image]]">
-        <div hidden$="[[!heading]]" class$="[[_computeHeadingClass(image)]]">[[heading]]</div>
-      </div>
+    <paper-material animated$="[[animatedShadow]]" elevation="[[elevation]]"></paper-material>
 
-      <content></content>
+    <div class="header">
+      <img hidden$="[[!image]]" src="[[image]]">
+      <div hidden$="[[!heading]]" class$="[[_computeHeadingClass(image)]]">[[heading]]</div>
+    </div>
 
-    </paper-material>
-
+    <content></content>
   </template>
 
 </dom-module>


### PR DESCRIPTION
The `paper-material` size was partly fixed in https://github.com/PolymerElements/paper-card/pull/19 but not sufficiently. If you apply this style to the card:
```css
paper-card {
  width: 300px;
  height: 100px;
  background-color: #ccc;
  padding-right: 30px;
}
```
then you get this, which is still wrong:
<img width="326" alt="screen shot 2015-09-04 at 11 41 55 am" src="https://cloud.githubusercontent.com/assets/1369170/9691890/47e51070-52fa-11e5-92d2-ac1021b72e24.png">

This fixes that.


(Note: this fix needs to be applied to paper-button, which suffers from the same problem)

👉 @frankiefu @cdata 