### PR TITLE
fix header rounded corners

### DIFF
--- a/paper-card.html
+++ b/paper-card.html
@@ -31,7 +31,7 @@ Example - top card image:
     <paper-card heading="Card Title" image="/path/to/image.png">
       ...
     </paper-card>
-    
+
 ### Accessibility
 
 By default, the `aria-label` will be set to the value of the `heading` attribute.
@@ -81,6 +81,9 @@ Custom property | Description | Default
 
       .header {
         position: relative;
+        border-top-left-radius: inherit;
+        border-top-right-radius: inherit;
+        overflow: hidden;
         @apply(--paper-card-header);
       }
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-card/issues/24

With an exaggerated `border-radius` on the host,

Before:
<img width="446" alt="screen shot 2015-10-19 at 2 47 02 pm" src="https://cloud.githubusercontent.com/assets/1369170/10592354/6fd55524-7670-11e5-8b30-d94615ea9b3f.png">

After:
<img width="429" alt="screen shot 2015-10-19 at 2 46 53 pm" src="https://cloud.githubusercontent.com/assets/1369170/10592356/73080804-7670-11e5-9c87-b3840d090ac4.png">


