### PR TITLE
use iron-image instead of img

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,18 +20,19 @@
   "homepage": "https://github.com/PolymerElements/paper-card",
   "ignore": [],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.1.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
+    "iron-image": "PolymerElements/iron-image#~1.0.2",
     "paper-material": "PolymerElements/paper-material#^1.0.0",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0"
+    "polymer": "Polymer/polymer#^1.1.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
+    "paper-button": "PolymerElements/paper-button#^1.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "*",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
-    "paper-button": "PolymerElements/paper-button#^1.0.0",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/paper-card.html
+++ b/paper-card.html
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-material/paper-material.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../iron-image/iron-image.html">
 
 <!--
 Material design: [Cards](https://www.google.com/design/spec/components/cards.html)
@@ -82,8 +83,9 @@ Custom property | Description | Default
         @apply(--paper-card-header);
       }
 
-      .header img {
+      .header iron-image {
         width: 100%;
+        --iron-image-width: 100%;
         pointer-events: none;
         @apply(--paper-card-header-image);
       }
@@ -117,7 +119,7 @@ Custom property | Description | Default
     </style>
 
     <div class="header">
-      <img hidden$="[[!image]]" src="[[image]]">
+      <iron-image hidden$="[[!image]]" src="[[image]]" preload$="[[preloadImage]]" fade$="[[fadeImage]]"></iron-image>
       <div hidden$="[[!heading]]" class$="[[_computeHeadingClass(image)]]">[[heading]]</div>
     </div>
 
@@ -149,6 +151,24 @@ Custom property | Description | Default
       image: {
         type: String,
         value: ''
+      },
+
+      /**
+       * When `true`, any change to the image url property will cause the
+       * `placeholder` image to be shown until the image is fully rendered.
+       */
+      preloadImage: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
+       * When `preloadImage` is true, setting `fadeImage` to true will cause the
+       * image to fade into place.
+       */
+      fadeImage: {
+        type: Boolean,
+        value: false
       },
 
       /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -39,16 +39,49 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     suite('a11y', function() {
+      var f;
+      setup(function () {
+        f = fixture('basic');
+      });
+
       test('aria-label set on card', function() {
-        var f = fixture('basic');
         assert.strictEqual(f.getAttribute('aria-label'), f.heading);
       });
 
       test('aria-label can be updated', function() {
-        var f = fixture('basic');
         assert.strictEqual(f.getAttribute('aria-label'), f.heading);
         f.heading = 'batman';
         assert.strictEqual(f.getAttribute('aria-label'), 'batman');
+      });
+    });
+    suite('header image', function() {
+      var f, img;
+      setup(function () {
+        f = fixture('basic');
+        img = f.querySelector('iron-image');
+      });
+
+      test('is iron-image', function(){
+        expect(img).to.be.ok;
+      });
+
+      test('width properly setup', function() {
+        assert.strictEqual(img.offsetWidth, 0);
+        f.image = 'some-img-url';
+        assert.strictEqual(img.src, f.image);
+        assert.strictEqual(img.offsetWidth, f.offsetWidth);
+      });
+
+      test('preload properly setup', function() {
+        assert.strictEqual(img.preload, f.preloadImage);
+        f.preloadImage = !f.preloadImage;
+        assert.strictEqual(img.preload, f.preloadImage);
+      });
+
+      test('fade properly setup', function() {
+        assert.strictEqual(img.fade, f.fadeImage);
+        f.fadeImage = !f.fadeImage;
+        assert.strictEqual(img.fade, f.fadeImage);
       });
     });
   </script>


### PR DESCRIPTION
Fixes #27 by using iron-image with preload and fade properties.

Depends on https://github.com/PolymerElements/iron-image/pull/28, without it paper-card image will render like this:
![screen shot 2015-10-30 at 4 40 26 pm](https://cloud.githubusercontent.com/assets/6173664/10860417/f4a478a4-7f24-11e5-9a3a-47cce16fe86e.png)