### PR TITLE
add demo for expand-for-more-info

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "polymer": "Polymer/polymer#^1.1.0"
   },
   "devDependencies": {
+    "iron-collapse": "PolymerElements/iron-collapse#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "paper-button": "PolymerElements/paper-button#^1.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,7 +20,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../paper-card.html">
   <link rel="import" href="../../paper-button/paper-button.html">
   <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
+  <link rel="import" href="../../iron-collapse/iron-collapse.html">
   <link rel="import" href="../../iron-icons/iron-icons.html">
+  <link rel="import" href="../../iron-icons/hardware-icons.html">
   <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
   <link rel="import" href="../../paper-styles/color.html">
 
@@ -126,6 +128,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div class="card-actions">
         <paper-button>Nay</paper-button>
         <paper-button>Yay!</paper-button>
+        <template is="dom-bind" id="expand-demo">
+          <paper-icon-button
+              icon="hardware:keyboard-arrow-down"
+              title="more info"
+              on-tap="_toggleMoreInfo"
+              style="float: right;">
+          </paper-icon-button>
+          <iron-collapse id="more-info">
+            Pro saepe pertinax ei, ad pri animal labores suscipiantur. Modus commodo minimum eum te, vero utinam assueverit per eu, zril oportere suscipiantur pri te. Partem percipitur deterruisset ad sea, at eam suas luptatum dissentiunt. No error alienum pro, erant senserit ex mei, pri semper alterum no. Ut habemus menandri vulputate mea. Feugiat verterem ut sed. Dolores maiestatis id per. Pro saepe pertinax ei, ad pri animal labores suscipiantur. Modus commodo minimum eum te, vero utinam assueverit per eu, zril oportere suscipiantur pri te. Partem percipitur deterruisset ad sea, at eam suas luptatum dissentiunt. No error alienum pro, erant senserit ex mei, pri semper alterum no. Ut habemus menandri vulputate mea. Feugiat verterem ut sed. Dolores maiestatis id per.
+          </iron-collapse>
+        </template>
       </div>
     </paper-card>
 
@@ -173,15 +186,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </div>
 
   <script>
-   function decreaseShadow() {
-     var card = document.querySelector('#shadow_demo');
-     card.elevation = card.elevation > 0 ? card.elevation - 1 : 0;
-   }
+    function decreaseShadow() {
+      var card = document.querySelector('#shadow_demo');
+      card.elevation = card.elevation > 0 ? card.elevation - 1 : 0;
+    }
 
-   function increaseShadow() {
-     var card = document.querySelector('#shadow_demo');
-     card.elevation = card.elevation < 5 ? card.elevation + 1 : 5;
-   }
+    function increaseShadow() {
+      var card = document.querySelector('#shadow_demo');
+      card.elevation = card.elevation < 5 ? card.elevation + 1 : 5;
+    }
+
+    var expandDemo = document.getElementById('expand-demo');
+
+    expandDemo._toggleMoreInfo = function(event) {
+      var moreInfo = document.getElementById('more-info');
+      var iconButton = Polymer.dom(event).localTarget;
+      iconButton.icon = moreInfo.opened ? 'hardware:keyboard-arrow-down'
+                                        : 'hardware:keyboard-arrow-up';
+      moreInfo.toggle();
+    };
  </script>
 
 </body>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-card/issues/39

Not expanded:
<img width="430" alt="screen shot 2015-11-09 at 12 18 26 pm" src="https://cloud.githubusercontent.com/assets/1369170/11045388/112c7134-86dc-11e5-9536-0159921913e6.png">

Expanded:
<img width="427" alt="screen shot 2015-11-09 at 12 18 30 pm" src="https://cloud.githubusercontent.com/assets/1369170/11045394/13c02d28-86dc-11e5-8a18-1cbc9030b5be.png">
