### PR TITLE
Remove unnecessary CSS and organice the styles

### DIFF
--- a/paper-card.html
+++ b/paper-card.html
@@ -64,15 +64,10 @@ Custom property | Description | Default
         display: inline-block;
         position: relative;
         box-sizing: border-box;
-
         background: #fff;
         border-radius: 2px;
-        @apply(--paper-card);
-      }
 
-      /* IE 10 support for HTML5 hidden attr */
-      [hidden] {
-        display: none !important;
+        @apply(--paper-card);
       }
 
       .header {


### PR DESCRIPTION
Remove unnecessary CSS and organice the styles like the other paper-elements (applys separately from other styles)

This is in the iron-flex-layout:

```css
/* IE 10 support for HTML5 hidden attr */
[hidden] {		
  display: none !important;		
}
```