### PR TITLE
up arrow default for un-expanded content in demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -130,7 +130,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <paper-button>Yay!</paper-button>
         <template is="dom-bind" id="expand-demo">
           <paper-icon-button
-              icon="hardware:keyboard-arrow-down"
+              icon="hardware:keyboard-arrow-up"
               title="more info"
               on-tap="_toggleMoreInfo"
               style="float: right;">
@@ -201,8 +201,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     expandDemo._toggleMoreInfo = function(event) {
       var moreInfo = document.getElementById('more-info');
       var iconButton = Polymer.dom(event).localTarget;
-      iconButton.icon = moreInfo.opened ? 'hardware:keyboard-arrow-down'
-                                        : 'hardware:keyboard-arrow-up';
+      iconButton.icon = moreInfo.opened ? 'hardware:keyboard-arrow-up'
+                                        : 'hardware:keyboard-arrow-down';
       moreInfo.toggle();
     };
  </script>


### PR DESCRIPTION
Hello, this is in reference to [issue #29](https://github.com/PolymerElements/paper-card/issues/39) for the demo. 

> This is minor, I just wanted to mention that on the Google Design site for the cards the arrow for unexpanded content is pointing upwards and in the demo it is pointing downwards.

![pic1](https://cloud.githubusercontent.com/assets/887815/12134409/b2733db2-b3f4-11e5-858d-c7178ff95f07.jpg)

![pic2](https://cloud.githubusercontent.com/assets/887815/12134415/b72b520e-b3f4-11e5-90c9-5f0ed83d7f44.jpg)
