### PR TITLE
Fixes #68

### DIFF
--- a/paper-card.html
+++ b/paper-card.html
@@ -88,7 +88,7 @@ Custom property | Description | Default
       }
 
       .header iron-image {
-        vertical-align: text-bottom;
+        display: block;
         width: 100%;
         --iron-image-width: 100%;
         pointer-events: none;

--- a/paper-card.html
+++ b/paper-card.html
@@ -88,6 +88,7 @@ Custom property | Description | Default
       }
 
       .header iron-image {
+        vertical-align: text-bottom;
         width: 100%;
         --iron-image-width: 100%;
         pointer-events: none;


### PR DESCRIPTION
This fixes #68 by aligning the header image with text-bottom. The default baseline alignment leaves a few extra pixels below the image for text descenders.

An alternate fix would be to add `display:block;` to `.header iron-image`