### PR TITLE
Fix img placeholder

### DIFF
--- a/paper-card.html
+++ b/paper-card.html
@@ -129,7 +129,7 @@ Custom property | Description | Default
     </style>
 
     <div class="header">
-      <iron-image hidden$="[[!image]]" src="[[image]]" preload$="[[preloadImage]]" fade$="[[fadeImage]]"></iron-image>
+      <iron-image hidden$="[[!image]]" src="[[image]]" placeholder="[[placeholder]]" preload$="[[preloadImage]]" fade$="[[fadeImage]]"></iron-image>
       <div hidden$="[[!heading]]" class$="[[_computeHeadingClass(image)]]">[[heading]]</div>
     </div>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -69,6 +69,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.strictEqual(img.offsetWidth, f.offsetWidth);
       });
 
+      test('placeholder properly setup', function() {
+        f.placeholder = 'some-place-holder';
+        assert.strictEqual(img.placeholder, f.placeholder);
+        f.placeholder = !f.placeholder;
+        assert.strictEqual(img.placeholder, f.placeholder);
+      });
+
       test('preload properly setup', function() {
         assert.strictEqual(img.preload, f.preloadImage);
         f.preloadImage = !f.preloadImage;

--- a/test/basic.html
+++ b/test/basic.html
@@ -70,9 +70,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('placeholder properly setup', function() {
+        assert.strictEqual(img.placeholder, null);
         f.placeholder = 'some-place-holder';
-        assert.strictEqual(img.placeholder, f.placeholder);
-        f.placeholder = !f.placeholder;
         assert.strictEqual(img.placeholder, f.placeholder);
       });
 


### PR DESCRIPTION
Current placeholder attribute doesn't work correctly when preloadImage is true. The reason is the placeholder of the iron-image has not been linked to the paper-card placeholder.

Without change:

![Without change](https://media.giphy.com/media/xT8qAYR1Su67I1GvHq/giphy.gif)

Refering the placeholder to the iron-image:

`<iron-image hidden$="[[!image]]" src="[[image]]" placeholder="[[placeholder]]" preload$="[[preloadImage]]" fade$="[[fadeImage]]"></iron-image>`

![With change](https://media.giphy.com/media/3o72F8EeojRMonREti/giphy.gif)