### PR TITLE
Add aria-hidden tag to the iron-image header if there is no image.

### DIFF
--- a/paper-card.html
+++ b/paper-card.html
@@ -131,6 +131,7 @@ Custom property | Description | Default
     <div class="header">
       <iron-image
           hidden$="[[!image]]"
+          aria-hidden$="[[_isHidden(image)]]"
           src="[[image]]"
           alt="[[alt]]"
           placeholder="[[placeholderImage]]"
@@ -226,6 +227,14 @@ Custom property | Description | Default
           readOnly: true,
           computed: '_computeAnimated(animatedShadow)'
         }
+      },
+      
+      /**
+       * Format function for aria-hidden. Use the ! operator results in the
+       * empty string when given a falsy value.
+       */
+      _isHidden: function(image) {
+        return image ? 'false' : 'true';
       },
 
       _headingChanged: function(heading) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,9 +36,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     suite('a11y', function() {
-      var f;
+      var f, img;
       setup(function () {
         f = fixture('basic');
+        img = f.$$('iron-image');
       });
 
       test('aria-label set on card', function() {
@@ -49,6 +50,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.strictEqual(f.getAttribute('aria-label'), f.heading);
         f.heading = 'batman';
         assert.strictEqual(f.getAttribute('aria-label'), 'batman');
+      });
+  
+      test('aria-hidden is set on image', function() {
+        assert.strictEqual(img.getAttribute('aria-hidden'), 'true');
+	  });
+
+      test('aria-hidden is removed when image is set', function() {
+        f.image = 'some-image-url';
+        assert.strictEqual(img.getAttribute('aria-hidden'), 'false');
       });
     });
     suite('header image', function() {


### PR DESCRIPTION
ChromeVox would read "image" in rare circumstance when traversing over the paper-card element otherwise.

Fixes #85.