### PR TITLE
Bower install direction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Material design: [Cards](https://www.google.com/design/spec/components/cards.htm
 
 `paper-card` is a container with a drop shadow.
 
+## Install using Bower
+```
+bower install PolymerElements/paper-card
+```
+
 <!---
 ```html
 <custom-element-demo>


### PR DESCRIPTION
If you `bower install paper-card`, it installs something with all sort of issues (https://github.com/PolymerElements/paper-card/issues/106). This makes it clear what the package name is for bower installation.